### PR TITLE
conntrack: Free conntrack context in 'conntrack_destroy()'.

### DIFF
--- a/lib/conntrack.c
+++ b/lib/conntrack.c
@@ -391,6 +391,7 @@ conntrack_destroy(struct conntrack *ct)
     ct_rwlock_unlock(&ct->resources_lock);
     ct_rwlock_destroy(&ct->resources_lock);
     ipf_destroy(ct->ipf);
+    free(ct);
 }
 
 static unsigned hash_to_bucket(uint32_t hash)


### PR DESCRIPTION
Fixes: 57593fd24378 ( conntrack: Stop exporting internal datastructures.)
Signed-off-by: Darrell Ball <dlu998@gmail.com>
Signed-off-by: Ben Pfaff <blp@ovn.org>